### PR TITLE
criteres.html : correctif mineur de ponctuation pour le test-1-4-10

### DIFF
--- a/criteres.html
+++ b/criteres.html
@@ -345,7 +345,7 @@
 								</ul>
 							</li>
 							<li id="test-1-4-9">Test 1.4.9&nbsp;: Pour chaque image vectorielle (balise <code lang="en">svg</code>) utilisée comme <a href="glossaire.html#captcha">CAPTCHA</a> ou comme <a href="glossaire.html#image-test">image-test</a>, possédant une <a href="glossaire.html#alternative-svg">alternative</a>, cette alternative est-elle <a href="glossaire.html#correctement-restitue-par-les-technologies-dassistance">correctement restituée</a> par les technologies d'assistance&nbsp;?</li>
-							<li id="test-1-4-10">Test 1.4.10&nbsp; Chaque image <span lang="en">bitmap</span> (balise <code lang="en">canvas</code>) utilisée comme <a href="glossaire.html#captcha">CAPTCHA</a> ou comme <a href="glossaire.html#image-test">image-test</a> vérifie-t-elle une de ces conditions&nbsp;?
+							<li id="test-1-4-10">Test 1.4.10&nbsp;: Chaque image <span lang="en">bitmap</span> (balise <code lang="en">canvas</code>) utilisée comme <a href="glossaire.html#captcha">CAPTCHA</a> ou comme <a href="glossaire.html#image-test">image-test</a> vérifie-t-elle une de ces conditions&nbsp;?
 								<ul>
 								  <li>Le contenu de l'alternative (contenu entre <code lang="en">&lt;canvas&gt;</code> et <code lang="en">&lt;/canvas&gt;</code>) permet de comprendre la nature et la fonction de l'image.</li>
 								  <li>L'image <span lang="en">bitmap</span> est immédiatement suivie d'un <a href="glossaire.html#lien-adjacent">lien adjacent</a> permettant d'afficher une page ou un passage de texte contenant une alternative permettant de comprendre la nature et la fonction de l'image.</li>


### PR DESCRIPTION
le séparateur " **:**" entre le n° du test et sa description est absent

à noter, que sans une version normalisée type (csv, json), pour la récupération du nouveau référentiel, afin de pourvoir le manipuler informatiquement (par exemple pour l’intégrer au logiciel @Asqatasun), il faut scraper la page web… et les ":" manquant nécessite d’éditer manuellement le fichier HTML pour pouvoir parser le contenu totalement.  

une version normalisée (du rgaa 2016) existe dans le dépôt de l’extension de navigateur 
https://github.com/DISIC/assistant-rgaa/blob/master/data/references/3-2016.json

